### PR TITLE
Add Termux chat script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,34 @@ A basic AI assistant app to be developed and deployed.
 ## How to Run Locally
 
 1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set the `OPENAI_API_KEY` environment variable in your shell or in a `.env` file.
+3. Start the app:
+   ```bash
+   python app.py
+   ```
+
+## Using `termux_chatgpt.py` in Termux
+
+1. Install Python and Git in Termux:
+   ```bash
+   pkg install python git
+   ```
+2. Clone this repository and install the dependencies:
+   ```bash
+   git clone <repository-url>
+   cd Dreamer
+   pip install -r requirements.txt
+   ```
+3. Export your API key:
+   ```bash
+   export OPENAI_API_KEY=your-key
+   ```
+4. Run the script:
+   ```bash
+   python termux_chatgpt.py
+   ```
+
+Commands beginning with `!` inside the program will be executed directly in the Termux shell and the output will be printed.

--- a/termux_chatgpt.py
+++ b/termux_chatgpt.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+conversation = [
+    {"role": "system", "content": "You are a helpful Termux assistant. Commands beginning with '!' should be executed in the shell."}
+]
+
+while True:
+    user_input = input("You: ").strip()
+
+    if user_input.startswith("!"):
+        command = user_input[1:]
+        result = subprocess.getoutput(command)
+        print(result)
+        continue
+
+    conversation.append({"role": "user", "content": user_input})
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=conversation,
+        temperature=0.7,
+    )
+    message = response["choices"][0]["message"]["content"]
+    conversation.append({"role": "assistant", "content": message})
+    print(message)
+


### PR DESCRIPTION
## Summary
- add `termux_chatgpt.py` for running GPT interactions in Termux
- expand README with dependency install steps and instructions for using the script

## Testing
- `python -m py_compile termux_chatgpt.py`
- `git push origin work` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_684c5cae71d8832d9369100e86ed89c2