### PR TITLE
Add Termux ChatGPT helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,24 @@ A basic AI assistant app to be developed and deployed.
 ## How to Run Locally
 
 1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Using `termux_chatgpt.py`
+
+1. Ensure the `openai` Python package is installed (it's included in `requirements.txt`).
+2. Set the `OPENAI_API_KEY` environment variable with your OpenAI API key:
+
+   ```bash
+   export OPENAI_API_KEY=your_openai_api_key
+   ```
+
+3. Run the assistant in Termux:
+
+   ```bash
+   python termux_chatgpt.py
+   ```
+
+Commands starting with `!` will be executed in the Termux shell.

--- a/termux_chatgpt.py
+++ b/termux_chatgpt.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+conversation = [
+    {"role": "system", "content": "You are a helpful Termux assistant. Commands beginning with '!' should be executed in the shell."} 
+]
+
+while True:
+    user_input = input("You: ").strip()
+
+    if user_input.startswith("!"):
+        command = user_input[1:]
+        result = subprocess.getoutput(command)
+        print(result)
+        continue
+
+    conversation.append({"role": "user", "content": user_input})
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=conversation,
+        temperature=0.7,
+    )
+    message = response["choices"][0]["message"]["content"]
+    conversation.append({"role": "assistant", "content": message})
+    print(message)


### PR DESCRIPTION
## Summary
- add `termux_chatgpt.py` script for using ChatGPT in Termux
- document running the script and setting `OPENAI_API_KEY`

## Testing
- `python3 -m py_compile termux_chatgpt.py`

------
https://chatgpt.com/codex/tasks/task_e_6864502b530c832dbc11baecb42f5be6